### PR TITLE
improved argument formatting for error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem

--- a/lib/coque/sh.rb
+++ b/lib/coque/sh.rb
@@ -14,7 +14,7 @@ module Coque
     end
 
     def to_s
-      "<Coque::Sh #{args.inspect}>"
+      "<Coque::Sh #{args.join(" ")}>"
     end
 
     def inspect


### PR DESCRIPTION
before 

```
2.4.0 :002 > Coque["ls", "/path/does/not/exist"].run!
ls: cannot access '/path/does/not/exist': No such file or directory
RuntimeError: Coque Command Failed: <Coque::Sh ["ls", "/path/does/not/exist"]>
	from /home/benmayne/.rvm/gems/ruby-2.4.0/gems/coque-0.5.0/lib/coque/redirectable.rb:66:in `run!'
	from (irb):2
	from /home/benmayne/.rvm/rubies/ruby-2.4.0/bin/irb:11:in `<main>'
2.4.0 :003 > 
```

after

```
2.4.0 :002 > Coque["ls", "/path/does/not/exist"].run!
ls: cannot access '/path/does/not/exist': No such file or directory
RuntimeError: Coque Command Failed: <Coque::Sh ls /path/does/not/exist>
	from /home/benmayne/.rvm/gems/ruby-2.4.0/gems/coque-0.5.0/lib/coque/redirectable.rb:66:in `run!'
	from (irb):2
	from /home/benmayne/.rvm/rubies/ruby-2.4.0/bin/irb:11:in `<main>'

```

I can now copy `ls /path/does/not/exist` from that output without having to deal with the array of strings